### PR TITLE
Update sentry dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Perafan18/adonis-sentry#readme",
   "dependencies": {
-    "@sentry/node": "^4.0.6"
+    "@sentry/node": "^5.4.3"
   },
   "devDependencies": {
     "dotenv": "^6.0.0",


### PR DESCRIPTION
Current version causes the following to display on all events within sentry:

> We recommend you update your SDK from version 4.6.6 to version 5.4.3